### PR TITLE
Remove more messages flag from local msg notification cbor encoding

### DIFF
--- a/dmq-node/cddl/specs/local-msg-notification.cddl
+++ b/dmq-node/cddl/specs/local-msg-notification.cddl
@@ -13,7 +13,9 @@ msgRequestMessages          = [0, isBlocking]
 ; the codec only accepts indefinite lists of messages
 msgReplyMessagesNonBlocking = [1, [*sig.message], hasMore]
 ; the codec only accepts indefinite lists of messages
-msgReplyMessagesBlocking    = [2, [+sig.message], hasMore]
+; Issue #15
+; msgReplyMessagesBlocking    = [2, [+sig.message], hasMore]
+msgReplyMessagesBlocking    = [2, [+sig.message]]
 msgClientDone               = [3]
 
 ;# import sig as sig

--- a/dmq-node/test/DMQ/Protocol/LocalMsgNotification/Test.hs
+++ b/dmq-node/test/DMQ/Protocol/LocalMsgNotification/Test.hs
@@ -230,7 +230,9 @@ instance Arbitrary msg => Arbitrary (AnyMessage (LocalMsgNotification msg)) wher
     [ pure . AnyMessage . MsgRequest $ SingBlocking
     , pure . AnyMessage . MsgRequest $ SingNonBlocking
     , AnyMessage <$>
-        (MsgReply . BlockingReply . NE.fromList . QC.getNonEmpty <$> arbitrary <*> arbitrary)
+        -- Issue #15
+        -- (MsgReply . BlockingReply . NE.fromList . QC.getNonEmpty <$> arbitrary <*> arbitrary)
+        (MsgReply . BlockingReply . NE.fromList . QC.getNonEmpty <$> arbitrary <*> pure DoesNotHaveMore)
     , AnyMessage <$>
         (MsgReply . NonBlockingReply <$> arbitrary <*> arbitrary)
     , pure $ AnyMessage MsgClientDone


### PR DESCRIPTION
Currently, CIP-0137 does not allow a blocking request for messages over local message notification protocol to additionally return a boolean flag indicating whether more messages are still available. The expectation is that a non-blocking call should be made to retrieve those. Until the CIP is updated, this patch removes this flag from the encoding, and modifies tests accordingly. This patch should be eventually reverted.

resolves #15 

## Checklist

- [related issue](https://github.com/IntersectMBO/xxxx/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/xxxx/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
