### PR TITLE
Prometheus prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ The `Prometheus` requires a different port number than `cardano-node`'s
 }
 ```
 
-By default all counters are prefixed with `dmq-node_`, this can be changed with
+By default all counters are prefixed with `dmq_node_`, this can be changed with
 `TraceOptionMetricsPrefix` option in the configuration file, e.g.
 ```json
 {
-  "TraceOptionMetricsPrefix": "dmq-aggregator"
+  "TraceOptionMetricsPrefix": "dmq_aggregator."
 }
 ```
 

--- a/dmq-node/src/DMQ/Tracer.hs
+++ b/dmq-node/src/DMQ/Tracer.hs
@@ -200,6 +200,12 @@ type DMQDiffusionTracers m =
 type PrometheusConfig = Maybe (Bool, Maybe HostName, PortNumber)
 
 
+-- | Default metrics prefix, it is transformed into `dmq_node_` in `Prometheus`.
+--
+metricsPrefix :: Text
+metricsPrefix = "dmq_node."
+
+
 -- | Create and configure `DMQTracers` and `DMQDiffusionTracers`.
 --
 mkDMQTracers
@@ -229,14 +235,15 @@ mkDMQTracers ekgStore dmqConfigFilePath = do
         Logging.DNormal
         (Logging.Stdout Logging.MachineFormat)
         dmqConfigFilePath
-        Logging.emptyTraceConfig { Logging.tcMetricsPrefix = Just "dmq-node_" }
+        Logging.emptyTraceConfig
+        { Logging.tcMetricsPrefix = Just metricsPrefix }
     else
       return
         (Logging.mkConfigurationWithFallback
           Logging.Info
           Logging.DNormal
           (Logging.Stdout Logging.MachineFormat)
-        ) { Logging.tcMetricsPrefix = Just "dmq-node_" }
+        ) { Logging.tcMetricsPrefix = Just metricsPrefix }
 
   ekgTrace <- Logging.ekgTracer traceConfig ekgStore
 


### PR DESCRIPTION
* Prometheus doesn't allow for dash in metric names, they are rewritten
  with an underscore.
* Trace dispatcher is using `.` for name space prefixes, so we terminate
  it with a dot rather than `_` (trace dispatcher will rewrite it into
  `_`).
  
Credits go to @mgmeier for spotting the inconsitencies. 
