### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -69,7 +69,7 @@ let
     utils.flattenDerivationTree "-"
       {
         "x86_64-linux" = defaultHydraJobs;
-        "x86_64-darwin" = defaultHydraJobs;
+        "x86_64-darwin" = { };
         "aarch64-linux" = { };
         "aarch64-darwin" = defaultHydraJobs;
       }.${system};


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/xxxx/tree/main/docs/style-guides) of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
