### PR TITLE
Update CHaP index-state and bump ouroboros-consensus to v4.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ index-state:
   , hackage.haskell.org 2026-07-30T07:30:12Z
 
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-07-30T16:22:40Z
+  , cardano-haskell-packages 2026-08-11T14:53:43Z
 
 packages:
   ./dmq-node

--- a/dmq-node/changelog.d/20260812_kolam_bump_consensus_4_1.md
+++ b/dmq-node/changelog.d/20260812_kolam_bump_consensus_4_1.md
@@ -1,0 +1,21 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Non-Breaking
+
+- Bump `ouroboros-consensus` to `v4.1`.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/dmq-node/dmq-node.cabal
+++ b/dmq-node/dmq-node.cabal
@@ -134,7 +134,7 @@ library
     network-mux ^>=0.11,
     nothunks,
     optparse-applicative >=0.18 && <0.20,
-    ouroboros-consensus:{ouroboros-consensus, cardano, diffusion} ^>=4.0,
+    ouroboros-consensus:{ouroboros-consensus, cardano, diffusion} ^>=4.1,
     ouroboros-network:{ouroboros-network, api, framework, orphan-instances, protocols, tracing} ^>=1.2,
     psqueues,
     quiet,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1785429959,
-        "narHash": "sha256-11V+x8LMNOl1k3n5SlL6EJhXOADdqBI21UmAl5HNSVY=",
+        "lastModified": 1786489982,
+        "narHash": "sha256-T0r6CvdSEDxszlb7uK7mxEVZcCtFNbk8tlr8B1bRKqM=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "7ce63459d3adbf8ed6b505b627ea75ce77701f39",
+        "rev": "13d0f23cf6af9ea55194b91f6947c0a2aeb522d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## List of changes

- Update CHaP index-state to bump ouroboros-consensus to v4.1

## Checklist

- [related issue](https://github.com/IntersectMBO/xxxx/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/xxxx/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
